### PR TITLE
fix: Post-merge cleanup - Pydantic V2 + Ruff config

### DIFF
--- a/logs/autonomous_healing/constitutional_violations.jsonl
+++ b/logs/autonomous_healing/constitutional_violations.jsonl
@@ -187,3 +187,7 @@
 {"timestamp": "2025-10-04T12:18:18.190347+00:00", "violation_type": "ConstitutionalCompliance", "function": "create_mock_agent", "error": "Article II: Quality standards not met", "severity": "BLOCKER"}
 {"timestamp": "2025-10-04T12:30:27.671272+00:00", "violation_type": "ConstitutionalCompliance", "function": "create_mock_agent", "error": "Article I: Incomplete context", "severity": "BLOCKER"}
 {"timestamp": "2025-10-04T12:30:27.674909+00:00", "violation_type": "ConstitutionalCompliance", "function": "create_mock_agent", "error": "Article II: Quality standards not met", "severity": "BLOCKER"}
+{"timestamp": "2025-10-04T13:57:23.298550+00:00", "violation_type": "ConstitutionalCompliance", "function": "create_mock_agent", "error": "Article I: Incomplete context", "severity": "BLOCKER"}
+{"timestamp": "2025-10-04T13:57:23.301411+00:00", "violation_type": "ConstitutionalCompliance", "function": "create_mock_agent", "error": "Article II: Quality standards not met", "severity": "BLOCKER"}
+{"timestamp": "2025-10-04T14:11:02.691669+00:00", "violation_type": "ConstitutionalCompliance", "function": "create_mock_agent", "error": "Article I: Incomplete context", "severity": "BLOCKER"}
+{"timestamp": "2025-10-04T14:11:02.693983+00:00", "violation_type": "ConstitutionalCompliance", "function": "create_mock_agent", "error": "Article II: Quality standards not met", "severity": "BLOCKER"}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,6 +70,8 @@ log_cli_date_format = "%Y-%m-%d %H:%M:%S"
 [tool.ruff]
 target-version = "py311"
 line-length = 100
+
+[tool.ruff.lint]
 select = [
     "E",   # pycodestyle errors
     "W",   # pycodestyle warnings
@@ -86,7 +88,7 @@ ignore = [
 ]
 unfixable = ["B"]
 
-[tool.ruff.per-file-ignores]
+[tool.ruff.lint.per-file-ignores]
 "tests/**/*.py" = [
     "S101",  # Use of assert in tests is OK
     "ARG",   # Unused function arguments in tests are OK
@@ -209,7 +211,7 @@ unfixable = ["B"]
     "F821",  # Undefined names (dynamic/generated code)
 ]
 
-[tool.ruff.isort]
+[tool.ruff.lint.isort]
 known-first-party = ["agency", "shared", "tools"]
 
 [tool.ruff.format]

--- a/shared/cost_tracker.py
+++ b/shared/cost_tracker.py
@@ -39,7 +39,7 @@ from datetime import datetime, timedelta
 from enum import Enum
 from pathlib import Path
 
-from pydantic import BaseModel, Field, validator
+from pydantic import BaseModel, Field, field_validator
 
 from shared.type_definitions.json_value import JSONValue
 from shared.type_definitions.result import Err, Ok, Result
@@ -84,13 +84,15 @@ class CostEntry(BaseModel):
     metadata: JSONValue = Field(default_factory=dict)
     error: str | None = None
 
-    @validator("tokens_in", "tokens_out")
+    @field_validator("tokens_in", "tokens_out")
+    @classmethod
     def validate_positive(cls, v):
         if v < 0:
             raise ValueError("Token counts must be non-negative")
         return v
 
-    @validator("cost_usd")
+    @field_validator("cost_usd")
+    @classmethod
     def validate_cost(cls, v):
         if v < 0:
             raise ValueError("Cost must be non-negative")

--- a/shared/pattern_detector.py
+++ b/shared/pattern_detector.py
@@ -23,7 +23,7 @@ from collections.abc import Callable
 from dataclasses import dataclass
 from typing import Literal
 
-from pydantic import BaseModel, Field, validator
+from pydantic import BaseModel, Field, field_validator
 
 from shared.type_definitions.json_value import JSONValue
 
@@ -44,7 +44,8 @@ class Pattern(BaseModel):
     examples: list[JSONValue] = Field(default_factory=list, description="Example instances")
     metadata: JSONValue = Field(default_factory=dict, description="Additional metadata")
 
-    @validator("confidence")
+    @field_validator("confidence")
+    @classmethod
     def confidence_in_range(cls, v: float) -> float:
         """Ensure confidence is between 0 and 1."""
         if not 0.0 <= v <= 1.0:


### PR DESCRIPTION
## Summary

Post-merge cleanup fixing audit findings from PR #25.

### Changes

**Pydantic V2 Migration** (3 validators):
- ✅ shared/cost_tracker.py - 2 validators
- ✅ shared/pattern_detector.py - 1 validator
- ✅ Eliminates all Pydantic V1 deprecation warnings

**Ruff Config Update**:
- ✅ Migrated to [tool.ruff.lint] section
- ✅ Eliminates ruff deprecation warnings

### Validation
- ✅ 0 ruff violations
- ✅ 0 ruff warnings
- ✅ 0 Pydantic warnings
- ✅ All imports successful

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>