### PR TITLE
fix: Resolve CI blockers (Ruff syntax error + Pydantic warnings)

### DIFF
--- a/tools/property_testing.py
+++ b/tools/property_testing.py
@@ -115,7 +115,7 @@ if not HYPOTHESIS_AVAILABLE:
             return Err(error)
 
 
-    @st.composite
+@st.composite
 def json_value_strategy(draw, max_leaves=10):
     """
     Generate valid JSONValue instances for property testing.

--- a/trinity_protocol/core/models/patterns.py
+++ b/trinity_protocol/core/models/patterns.py
@@ -14,7 +14,7 @@ from datetime import datetime
 from enum import Enum
 from typing import Literal
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, ConfigDict, Field
 
 from shared.type_definitions import JSONValue
 
@@ -59,10 +59,7 @@ class DetectedPattern(BaseModel):
         default=None, description="Urgency level (low, medium, high, critical)"
     )
 
-    class Config:
-        """Pydantic config."""
-
-        use_enum_values = True
+    model_config = ConfigDict(use_enum_values=True)
 
 
 class PatternContext(BaseModel):
@@ -78,14 +75,11 @@ class PatternContext(BaseModel):
     duration_minutes: float = Field(..., gt=0.0, description="Duration of conversation in minutes")
     related_patterns: list[str] = Field(default_factory=list, description="IDs of related patterns")
     transcript_excerpts: list[str] = Field(
-        default_factory=list, max_items=5, description="Key transcript excerpts (max 5)"
+        default_factory=list, max_length=5, description="Key transcript excerpts (max 5)"
     )
     metadata: JSONValue = Field(default_factory=dict, description="Additional metadata")
 
-    class Config:
-        """Pydantic config."""
-
-        validate_assignment = True
+    model_config = ConfigDict(validate_assignment=True)
 
 
 class AmbientEvent(BaseModel):
@@ -106,10 +100,7 @@ class AmbientEvent(BaseModel):
     conversation_id: str | None = Field(default=None, description="Conversation segment ID")
     metadata: JSONValue = Field(default_factory=dict, description="Additional metadata")
 
-    class Config:
-        """Pydantic config."""
-
-        frozen = True
+    model_config = ConfigDict(frozen=True)
 
 
 class TopicCluster(BaseModel):


### PR DESCRIPTION
## Summary

Fixes two pre-existing issues in main that were blocking CI for PRs #39 and #38.

## Issues Fixed

### 1. Ruff Syntax Error (`tools/property_testing.py:119`)
**Error**: `Expected class, function definition or async function definition after decorator`

**Root Cause**: The `@st.composite` decorator on line 118 had incorrect indentation - the function definition on line 119 was indented when it should be at module level.

**Fix**: Removed extra indentation to properly align decorator with function definition.

### 2. Pydantic Deprecation Warnings (`trinity_protocol/core/models/patterns.py`)
**Warnings**:
- `Support for class-based config is deprecated, use ConfigDict instead`
- `max_items is deprecated, use max_length instead`

**Fix**: Updated 3 Pydantic models to V2 syntax:
- `DetectedPattern`: Changed `class Config` → `model_config = ConfigDict(use_enum_values=True)`
- `PatternContext`: Changed `class Config` → `model_config = ConfigDict(validate_assignment=True)` + `max_items` → `max_length`
- `AmbientEvent`: Changed `class Config` → `model_config = ConfigDict(frozen=True)`

## Impact

These were **pre-existing issues in main**, not caused by PRs #39 or #38:
- PR #39 only modifies `tests/test_continuous_audit.py`
- PR #38 only adds `TRINITY_MVP_TEST.md`

Both PRs passed all core tests but were blocked by these CI failures.

## Testing

✅ Verified Ruff no longer reports syntax error on line 119
✅ Verified Pydantic models import without deprecation warnings for these 3 models
✅ No functional changes - only syntax/API updates

## Unblocks

- PR #39: Trinity GitHub App MVP
- PR #38: Trinity MVP Test

🤖 Generated with [Claude Code](https://claude.com/claude-code)