### PR TITLE
fix: CI workflow bugs after PR #49

### DIFF
--- a/.github/workflows/auto-quarantine.yml
+++ b/.github/workflows/auto-quarantine.yml
@@ -35,8 +35,9 @@ jobs:
         run: |
           python tools/test_quarantine.py --check
 
-          # Count candidates
+          # Count candidates (remove newlines from grep output)
           CANDIDATE_COUNT=$(python tools/test_quarantine.py --check 2>&1 | grep -c "•" || echo "0")
+          CANDIDATE_COUNT=$(echo "$CANDIDATE_COUNT" | tr -d '\n')
           echo "candidate_count=$CANDIDATE_COUNT" >> $GITHUB_OUTPUT
 
           if [ "$CANDIDATE_COUNT" -gt 0 ]; then

--- a/.github/workflows/backlog-update.yml
+++ b/.github/workflows/backlog-update.yml
@@ -29,7 +29,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          uv pip install -e .
+          uv pip install --system -e .
 
       - name: Scan for skipped tests
         run: |


### PR DESCRIPTION
Fixes two failing CI workflows:

1. Auto-Quarantine: Remove newlines from grep causing integer error
2. Backlog Update: Add --system flag for uv pip in CI

Changes: 2 files, 3 lines